### PR TITLE
Add code coverage step to pytest.yml

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,23 +1,43 @@
-name:                  Tests
+name: Codebase tests
 
 on:
-  push:
-    branches:          [main]
   pull_request:
-    branches:          [main]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
-  run_tests:
-    runs-on:           ubuntu-latest
+  test:
+    runs-on: ubuntu-22.04
+
     steps:
-      - name:          checkout repo
-        uses:          actions/checkout@v3.0.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name:          run tests
+
+      - name: Install system dependencies
         run: |
-                      python -m venv venv
-                      source venv/bin/activate
-                      sudo apt-get -y install graphviz
-                      pip install -e .[test]
-                      pytest tests/
+          sudo apt-get install -y graphviz
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11.5
+          cache: 'pip'
+
+      - name: Run Tests
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -e .[test]
+          coverage run --source=genlm_grammar -m pytest --benchmark-disable
+          coverage json --omit "*/test*"
+          coverage report --omit "*/test*"
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![Docs](https://github.com/chi-collective/genlm-grammar/actions/workflows/docs.yml/badge.svg)](https://chi-collective.github.io/genlm-grammar/)
-[![Tests](https://github.com/chi-collective/genlm-grammar/actions/workflows/pytest.yml/badge.svg)](https://chi-collective.com/probcomp/genlm-grammar/actions/workflows/pytest.yml)
+[![Docs](https://github.com/chisym/genlm-grammar/actions/workflows/docs.yml/badge.svg)](https://chisym.github.io/genlm-grammar/)
+[![Tests](https://github.com/chisym/genlm-grammar/actions/workflows/pytest.yml/badge.svg)](https://chisym.com/chisym/genlm-grammar/actions/workflows/pytest.yml)
+[![codecov](https://codecov.io/github/chisym/genlm-grammar/graph/badge.svg?token=TQBAQ1uA6y)](https://codecov.io/github/chisym/genlm-grammar)
 
 # GenLM Grammar
 
@@ -52,7 +53,7 @@ A Python library for working with weighted context-free grammars (WCFGs), weight
 Clone the repository:
 
 ```bash
-git clone git@github.com:chi-collective/genlm-grammar.git
+git clone git@github.com:chisym/genlm-grammar.git
 cd genlm-grammar
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
+    "coverage",
     "pytest",
     "pytest-benchmark",
 ]


### PR DESCRIPTION
This PR:

- adds `pip` caching to `pytest.yml`
- checks test coverage and uploads a report to codecov.io after testing
- adds a markdown badge for code coverage to the README