### PR TITLE
Return +inf on divergent series

### DIFF
--- a/genlm/grammar/semiring.py
+++ b/genlm/grammar/semiring.py
@@ -300,6 +300,8 @@ class Log(Semiring):
         return abs(self.score - other.score)
 
     def star(self):
+        if self.score >= 0:
+            return Log(float("inf"))
         return Log(-np.log1p(-np.exp(self.score)))
 
     def __add__(self, other):
@@ -307,10 +309,7 @@ class Log(Semiring):
             return other
         if other == Log.zero:
             return self
-        if self.score > other.score:
-            return Log(self.score + np.log(1 + np.exp(other.score - self.score)))
-        else:
-            return Log(other.score + np.log(1 + np.exp(self.score - other.score)))
+        return Log(np.logaddexp(self.score, other.score))
 
     def __mul__(self, other):
         if self == Log.zero:

--- a/tests/test_wfsa_semiring.py
+++ b/tests/test_wfsa_semiring.py
@@ -1,5 +1,17 @@
-from genlm.grammar.semiring import Semiring
+from genlm.grammar.semiring import Log, Semiring
 from genlm.grammar.wfsa.base import WFSA
+
+
+def test_log_star_divergent_returns_inf():
+    # Closure of weight >= 1 diverges -> return +inf
+    assert Log(0.0).star() == Log(float("inf"))
+    assert Log(0.5).star() == Log(float("inf"))
+
+
+def test_log_add_absorbs_inf():
+    # +inf must absorb in __add__
+    assert (Log(float("inf")) + Log(1.0)).score == float("inf")
+    assert (Log(float("inf")) + Log(float("inf"))).score == float("inf")
 
 # def test_basics():
 #    from semirings import Symbol


### PR DESCRIPTION
`BoolFSA.from_regex(r"[\s\S]*PATTERN[\s\S]*")` produced NaN -> return +inf for score >= 0 and use np.logaddexp in `__add__` so +inf doesn't re-produce NaN via inf − inf.